### PR TITLE
DockerをDebianベースに

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
 
 COPY package.json yarn.lock ./
 RUN yarn install
+RUN yarn add npm-run-all --dev
 COPY . ./
 RUN yarn build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
 
 COPY package.json yarn.lock ./
 RUN yarn install
-RUN yarn add npm-run-all --dev
 COPY . ./
 RUN yarn build
 

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
 		"nested-property": "4.0.0",
 		"node-fetch": "2.6.7",
 		"nodemailer": "6.7.2",
+		"npm-run-all": "4.1.5",
 		"object-assign-deep": "0.4.0",
 		"os-utils": "0.0.14",
 		"p-cancelable": "4.0.0",
@@ -279,7 +280,6 @@
 		"eslint": "8.25.0",
 		"eslint-plugin-node": "11.1.0",
 		"eslint-plugin-vue": "9.6.0",
-		"mocha": "10.0.0",
-		"npm-run-all": "4.1.5"
+		"mocha": "10.0.0"
 	}
 }


### PR DESCRIPTION
## Summary
DockerをDebianベースに

misskey-assetsは使用していないので、submoduleは不要。

ビルドに必要なものまではdependenciesに入れておくという方針で、npm-run-allはdevDependenciesに移動。